### PR TITLE
Add get_run method to SampleRegistry

### DIFF
--- a/app/sample_registry/src/sample_registry/registrar.py
+++ b/app/sample_registry/src/sample_registry/registrar.py
@@ -30,6 +30,24 @@ class SampleRegistry(object):
             raise ValueError("Run does not exist %s" % acc)
         return run
 
+    def get_run(self, run_accession: int) -> Run | None:
+        """Return the ``Run`` record for ``run_accession``.
+
+        Parameters
+        ----------
+        run_accession:
+            Accession number identifying the sequencing run.
+
+        Returns
+        -------
+        Run | None
+            The ``Run`` instance if found, otherwise ``None``.
+        """
+
+        return self.session.scalar(
+            select(Run).where(Run.run_accession == run_accession)
+        )
+
     def register_run(
         self,
         run_date: str,

--- a/app/sample_registry/test/test_registrar.py
+++ b/app/sample_registry/test/test_registrar.py
@@ -53,6 +53,18 @@ def test_check_run_accession(db):
     assert registry.check_run_accession(1).run_accession == 1
 
 
+def test_get_run(db):
+    registry = SampleRegistry(db)
+    run = registry.get_run(1)
+    assert run.run_accession == 1
+    assert run.run_date == "2024-07-02"
+
+
+def test_get_run_doesnt_exist(db):
+    registry = SampleRegistry(db)
+    assert registry.get_run(9999) is None
+
+
 def test_check_run_accession_doesnt_exist(db):
     registry = SampleRegistry(db)
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- expose a `get_run` method on `SampleRegistry` to fetch run records
- cover `get_run` behavior with new tests

## Testing
- `PYTHONPATH=app/sample_registry/src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3611b2d6883238d2c5743f6a10e36