### PR TITLE
Add getter for runs by data URI substring

### DIFF
--- a/sample_registry/registrar.py
+++ b/sample_registry/registrar.py
@@ -55,6 +55,29 @@ class SampleRegistry:
             select(Run).where(Run.run_accession == run_accession)
         )
 
+    def get_runs_by_data_uri(self, substring: str) -> list[int]:
+        """Return run accessions whose ``data_uri`` contains ``substring``.
+
+        Parameters
+        ----------
+        substring:
+            Text that must be contained within the ``data_uri`` field.
+
+        Returns
+        -------
+        list[int]
+            Run accessions ordered ascending for runs whose ``data_uri``
+            contains ``substring``.
+        """
+
+        return list(
+            self.session.scalars(
+                select(Run.run_accession)
+                .where(Run.data_uri.contains(substring))
+                .order_by(Run.run_accession)
+            ).all()
+        )
+
     def get_samples(self, run_accession: int) -> list[Sample]:
         """Return the list of ``Sample`` records for ``run_accession``.
 

--- a/tests/test_registrar.py
+++ b/tests/test_registrar.py
@@ -65,6 +65,13 @@ def test_get_run_doesnt_exist(db):
     assert registry.get_run(9999) is None
 
 
+def test_get_runs_by_data_uri(db):
+    registry = SampleRegistry(db)
+    assert registry.get_runs_by_data_uri("run1") == [1]
+    assert registry.get_runs_by_data_uri("raw_data") == [1, 2, 3]
+    assert registry.get_runs_by_data_uri("not-a-uri") == []
+
+
 def test_check_run_accession_doesnt_exist(db):
     registry = SampleRegistry(db)
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- add a SampleRegistry.get_runs_by_data_uri helper that searches run data_uri values for a substring
- exercise the new lookup in the registrar tests

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'flask_sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68dc2158a6908323ad38e30e3ebf52d7